### PR TITLE
Phoenix LiveView identicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,15 @@
 # Identicon
 
-Generates simple identicon images in SVG format and serves them over a minimal
-web interface built with Plug and Cowboy. Users can preview and download
-identicons based on any input string.
+Phoenix 1.7 application that generates SVG identicons. The home page lets you preview
+and download images without page reloads. A shareable `?u=alice` query will auto-load
+the preview.
 
-## Installation
+## Development
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `identicon` to your list of dependencies in `mix.exs`:
+Fetch deps and start the server:
 
-```elixir
-def deps do
-  [
-    {:identicon, "~> 0.1.0"}
-  ]
-end
+```bash
+mix deps.get && mix phx.server
 ```
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/identicon>.
-
+Navigate to [`localhost:4000`](http://localhost:4000) to use the app.

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,7 @@
+import "./phoenix";
+import {Socket} from "phoenix";
+import {LiveSocket} from "phoenix_live_view";
+
+let csrfToken = document.querySelector("meta[name='csrf-token']")?.getAttribute("content");
+let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}});
+liveSocket.connect();

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,24 @@
+import Config
+
+config :identicon, IdenticonWeb.Endpoint,
+  url: [host: "localhost"],
+  render_errors: [formats: [html: IdenticonWeb.ErrorHTML], layout: false],
+  pubsub_server: Identicon.PubSub,
+  live_view: [signing_salt: "signsalt"]
+
+config :esbuild,
+  version: "0.7.0",
+  default: [
+    args: ~w(js/app.js --bundle --target=es2017 --outdir=../priv/static/assets),
+    cd: Path.expand("../assets", __DIR__),
+    env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
+  ]
+
+config :tailwind,
+  version: "3.3.3",
+  default: [
+    args: ~w(--config=tailwind.config.js --input=css/app.css --output=../priv/static/assets/app.css),
+    cd: Path.expand("../assets", __DIR__)
+  ]
+
+import_config "#{config_env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,7 @@
+import Config
+
+config :identicon, IdenticonWeb.Endpoint,
+  http: [port: 4000],
+  debug_errors: true,
+  code_reloader: true,
+  watchers: []

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -4,4 +4,6 @@ config :identicon, IdenticonWeb.Endpoint,
   http: [port: 4000],
   debug_errors: true,
   code_reloader: true,
-  watchers: []
+  watchers: [],
+  secret_key_base: "PdXCcU0WCa9tw5IMuGsee1VPdbtW2Cl0NI36LJBMVZUzs3dR1HarSStckb+CI+8G"
+

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,0 +1,5 @@
+import Config
+
+if config_env() == :prod do
+  config :identicon, IdenticonWeb.Endpoint, server: true
+end

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,7 @@
+import Config
+
+config :identicon, IdenticonWeb.Endpoint,
+  http: [port: 4002],
+  server: false
+
+config :logger, level: :warning

--- a/lib/identicon/application.ex
+++ b/lib/identicon/application.ex
@@ -3,7 +3,7 @@ defmodule Identicon.Application do
 
   def start(_type, _args) do
     children = [
-      {Plug.Cowboy, scheme: :http, plug: IdenticonWeb.Router, options: [port: 4000]}
+      IdenticonWeb.Endpoint
     ]
 
     opts = [strategy: :one_for_one, name: Identicon.Supervisor]

--- a/lib/identicon_web.ex
+++ b/lib/identicon_web.ex
@@ -1,0 +1,37 @@
+defmodule IdenticonWeb do
+  def controller do
+    quote do
+      use Phoenix.Controller, formats: [:html, :json], layouts: [html: IdenticonWeb.Layouts]
+      import Plug.Conn
+      alias IdenticonWeb.Router.Helpers, as: Routes
+    end
+  end
+
+  def html do
+    quote do
+      use Phoenix.Component
+      import Phoenix.HTML
+      alias IdenticonWeb.Router.Helpers, as: Routes
+    end
+  end
+
+  def router do
+    quote do
+      use Phoenix.Router, helpers: false
+      import Plug.Conn
+      import Phoenix.Controller
+      import Phoenix.LiveView.Router
+    end
+  end
+
+  def live_view do
+    quote do
+      use Phoenix.LiveView, layout: {IdenticonWeb.Layouts, :root}
+      alias IdenticonWeb.Router.Helpers, as: Routes
+    end
+  end
+
+  defmacro __using__(which) when is_atom(which) do
+    apply(__MODULE__, which, [])
+  end
+end

--- a/lib/identicon_web/components/core_components.ex
+++ b/lib/identicon_web/components/core_components.ex
@@ -1,0 +1,14 @@
+defmodule IdenticonWeb.CoreComponents do
+  use Phoenix.Component
+  import Phoenix.HTML.Form
+
+  def button(assigns) do
+    assigns = assign_new(assigns, :type, fn -> "button" end)
+    ~H"""
+    <button type={@type}
+      class="rounded bg-blue-600 text-white px-4 py-2 hover:bg-blue-700 shadow">
+      <%= render_slot(@inner_block) %>
+    </button>
+    """
+  end
+end

--- a/lib/identicon_web/components/layouts.ex
+++ b/lib/identicon_web/components/layouts.ex
@@ -1,0 +1,14 @@
+defmodule IdenticonWeb.Layouts do
+  use Phoenix.Component
+
+  def root(assigns) do
+    ~H"""
+    <!DOCTYPE html>
+    <html lang="en" class="h-full bg-gray-50 dark:bg-slate-900">
+    <body class="h-full">
+      <%= @inner_content %>
+    </body>
+    </html>
+    """
+  end
+end

--- a/lib/identicon_web/controllers/identicon_controller.ex
+++ b/lib/identicon_web/controllers/identicon_controller.ex
@@ -1,0 +1,16 @@
+defmodule IdenticonWeb.IdenticonController do
+  use IdenticonWeb, :controller
+
+  def show(conn, %{"username" => username} = params) do
+    svg = Identicon.image_svg(username)
+    conn = put_resp_content_type(conn, "image/svg+xml")
+
+    conn = if params["download"] do
+      put_resp_header(conn, "content-disposition", "attachment; filename=#{username}.svg")
+    else
+      conn
+    end
+
+    send_resp(conn, 200, svg)
+  end
+end

--- a/lib/identicon_web/endpoint.ex
+++ b/lib/identicon_web/endpoint.ex
@@ -1,0 +1,21 @@
+defmodule IdenticonWeb.Endpoint do
+  use Phoenix.Endpoint, otp_app: :identicon
+
+  socket "/live", Phoenix.LiveView.Socket
+
+  plug Plug.Static,
+    at: "/",
+    from: :identicon,
+    gzip: false,
+    only: ~w(assets)
+
+  plug Plug.RequestId
+  plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
+
+  plug Plug.Session,
+    store: :cookie,
+    key: "_identicon_key",
+    signing_salt: "signsalt"
+
+  plug IdenticonWeb.Router
+end

--- a/lib/identicon_web/error_html.ex
+++ b/lib/identicon_web/error_html.ex
@@ -1,0 +1,11 @@
+defmodule IdenticonWeb.ErrorHTML do
+  use IdenticonWeb, :html
+
+  def render("404.html", _assigns) do
+    "Not Found"
+  end
+
+  def render("500.html", _assigns) do
+    "Internal Server Error"
+  end
+end

--- a/lib/identicon_web/live/home_live.ex
+++ b/lib/identicon_web/live/home_live.ex
@@ -1,0 +1,42 @@
+defmodule IdenticonWeb.HomeLive do
+  use IdenticonWeb, :live_view
+  alias Phoenix.LiveView.JS
+
+  def mount(params, _session, socket) do
+    username = params["u"]
+    {:ok, assign_svg(socket, username)}
+  end
+
+  def handle_event("generate", %{"username" => username}, socket) do
+    {:noreply,
+      socket
+      |> assign_svg(username)
+      |> push_patch(to: "/?u=#{username}")}
+  end
+
+  defp assign_svg(socket, nil), do: assign(socket, username: nil, svg: nil)
+  defp assign_svg(socket, ""), do: assign(socket, username: nil, svg: nil)
+  defp assign_svg(socket, username) do
+    assign(socket, username: username, svg: Identicon.image_svg(username))
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div class="min-h-screen flex flex-col items-center justify-center p-4">
+      <.form for={:identicon} phx-submit="generate" class="space-x-2 flex">
+        <input type="text" name="username" value={@username || ""} class="border rounded p-2" placeholder="username" />
+        <.button>Generate</.button>
+      </.form>
+
+      <%= if @svg do %>
+        <div class="mt-6 flex flex-col items-center space-y-4">
+          <img src={"/identicon/#{@username}"} class="w-64 h-64" />
+          <.button>
+            <a href={"/identicon/#{@username}?download=1"}>Download SVG</a>
+          </.button>
+        </div>
+      <% end %>
+    </div>
+    """
+  end
+end

--- a/lib/identicon_web/router.ex
+++ b/lib/identicon_web/router.ex
@@ -1,41 +1,19 @@
 defmodule IdenticonWeb.Router do
-  use Plug.Router
-  use Plug.ErrorHandler
+  use IdenticonWeb, :router
 
-  plug :match
-  plug :fetch_query_params
-  plug :dispatch
-
-  get "/" do
-    send_resp(conn, 200, "<html><body><form action='/preview' method='get'><input name='username'/><button>Generate</button></form></body></html>")
+  pipeline :browser do
+    plug :accepts, ["html"]
+    plug :fetch_session
+    plug :fetch_live_flash
+    plug :put_root_layout, {IdenticonWeb.Layouts, :root}
+    plug :protect_from_forgery
+    plug :put_secure_browser_headers
   end
 
-  get "/preview" do
-    case conn.params["username"] do
-      nil -> send_resp(conn, 400, "username required")
-      "" -> send_resp(conn, 400, "username required")
-      username ->
-        body = "<html><body><img src='/identicon/#{username}' /><br/><a href='/identicon/#{username}?download=1'>Download</a></body></html>"
-        send_resp(conn, 200, body)
-    end
-  end
+  scope "/", IdenticonWeb do
+    pipe_through :browser
 
-  get "/identicon/:username" do
-    svg = Identicon.image_svg(username)
-    conn = put_resp_content_type(conn, "image/svg+xml")
-    conn = if conn.params["download"] do
-      put_resp_header(conn, "content-disposition", "attachment; filename=#{username}.svg")
-    else
-      conn
-    end
-    send_resp(conn, 200, svg)
-  end
-
-  match _ do
-    send_resp(conn, 404, "not found")
-  end
-
-  def handle_errors(conn, _info) do
-    send_resp(conn, conn.status, "error")
+    live "/", HomeLive, :index
+    get "/identicon/:username", IdenticonController, :show
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -22,19 +22,19 @@ defmodule Identicon.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:mime, github: "elixir-plug/mime", tag: "v2.0.3", override: true},
-      {:plug_crypto, github: "elixir-plug/plug_crypto", tag: "v1.2.5", override: true},
-      {:telemetry, github: "beam-telemetry/telemetry", tag: "v1.2.1", override: true},
-      {:plug, github: "elixir-plug/plug", tag: "v1.15.3", override: true},
-      {:cowboy, github: "ninenines/cowboy", tag: "2.10.0", override: true},
-      {:cowboy_telemetry, github: "beam-telemetry/cowboy_telemetry", tag: "v0.4.0", override: true},
-      {:plug_cowboy, github: "elixir-plug/plug_cowboy", tag: "v2.6.1", override: true},
-      {:phoenix, github: "phoenixframework/phoenix", tag: "v1.7.10"},
-      {:phoenix_pubsub, github: "phoenixframework/phoenix_pubsub", tag: "v2.1.3"},
-      {:phoenix_html, github: "phoenixframework/phoenix_html", tag: "v3.3.4"},
-      {:phoenix_live_view, github: "phoenixframework/phoenix_live_view", tag: "v0.19.5"},
-      {:esbuild, github: "phoenixframework/esbuild", tag: "v0.7.0", runtime: Mix.env() == :dev},
-      {:tailwind, github: "phoenixframework/tailwind", tag: "v0.1.10", runtime: Mix.env() == :dev}
+      {:mime, "~> 2.0", override: true},
+      {:plug_crypto, "~> 1.2", override: true},
+      {:telemetry, "~> 1.2", override: true},
+      {:plug, "~> 1.15", override: true},
+      {:cowboy, "~> 2.10", override: true},
+      {:cowboy_telemetry, "~> 0.4", override: true},
+      {:plug_cowboy, "~> 2.6", override: true},
+      {:phoenix, "~> 1.7.10"},
+      {:phoenix_pubsub, "~> 2.1"},
+      {:phoenix_html, "~> 3.3"},
+      {:phoenix_live_view, "~> 0.19.5"},
+      {:esbuild, "~> 0.7", runtime: Mix.env() == :dev},
+      {:tailwind, "~> 0.1.10", runtime: Mix.env() == :dev}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,13 @@ defmodule Identicon.MixProject do
       {:plug, github: "elixir-plug/plug", tag: "v1.15.3", override: true},
       {:cowboy, github: "ninenines/cowboy", tag: "2.10.0", override: true},
       {:cowboy_telemetry, github: "beam-telemetry/cowboy_telemetry", tag: "v0.4.0", override: true},
-      {:plug_cowboy, github: "elixir-plug/plug_cowboy", tag: "v2.6.1", override: true}
+      {:plug_cowboy, github: "elixir-plug/plug_cowboy", tag: "v2.6.1", override: true},
+      {:phoenix, github: "phoenixframework/phoenix", tag: "v1.7.10"},
+      {:phoenix_pubsub, github: "phoenixframework/phoenix_pubsub", tag: "v2.1.3"},
+      {:phoenix_html, github: "phoenixframework/phoenix_html", tag: "v3.3.4"},
+      {:phoenix_live_view, github: "phoenixframework/phoenix_live_view", tag: "v0.19.5"},
+      {:esbuild, github: "phoenixframework/esbuild", tag: "v0.7.0", runtime: Mix.env() == :dev},
+      {:tailwind, github: "phoenixframework/tailwind", tag: "v0.1.10", runtime: Mix.env() == :dev}
     ]
   end
 end

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './js/**/*.js',
+    '../lib/*_web/**/*.*ex'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/test/identicon_web/home_live_test.exs
+++ b/test/identicon_web/home_live_test.exs
@@ -1,0 +1,17 @@
+defmodule IdenticonWeb.HomeLiveTest do
+  use ExUnit.Case, async: true
+  use Phoenix.ConnTest
+  import Phoenix.LiveViewTest
+
+  @endpoint IdenticonWeb.Endpoint
+
+  test "displays form" do
+    {:ok, view, _html} = live(build_conn(), "/")
+    assert has_element?(view, "form")
+  end
+
+  test "shareable url loads preview" do
+    {:ok, view, _html} = live(build_conn(), "/?u=bob")
+    assert has_element?(view, "img")
+  end
+end

--- a/test/identicon_web/router_test.exs
+++ b/test/identicon_web/router_test.exs
@@ -1,0 +1,18 @@
+defmodule IdenticonWeb.RouterTest do
+  use ExUnit.Case, async: true
+  use Phoenix.ConnTest
+
+  @endpoint IdenticonWeb.Endpoint
+
+  test "GET /identicon/test returns image" do
+    conn = get(build_conn(), "/identicon/test")
+    assert conn.status == 200
+    assert List.first(get_resp_header(conn, "content-type")) =~ "image/svg+xml"
+    assert conn.resp_body =~ "<svg"
+  end
+
+  test "GET /identicon/test?download=1 sets disposition" do
+    conn = get(build_conn(), "/identicon/test?download=1")
+    assert List.first(get_resp_header(conn, "content-disposition")) =~ "attachment"
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
 ExUnit.start()
+{:ok, _} = Application.ensure_all_started(:identicon)


### PR DESCRIPTION
## Summary
- upgrade to a Phoenix 1.7 structure
- add LiveView home page with identicon preview/download
- keep /identicon/:username endpoint for SVG output
- style with Tailwind CSS
- update tests and README

## Testing
- `mix test` *(fails: requires Hex install)*

------
https://chatgpt.com/codex/tasks/task_e_684ab44939148333b8d5ef8da51d8288