### PR TITLE
Fix missing CSRF meta tag in layout

### DIFF
--- a/lib/identicon_web/components/layouts.ex
+++ b/lib/identicon_web/components/layouts.ex
@@ -5,6 +5,13 @@ defmodule IdenticonWeb.Layouts do
     ~H"""
     <!DOCTYPE html>
     <html lang="en" class="h-full bg-gray-50 dark:bg-slate-900">
+    <head>
+      <meta charset="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <meta name="csrf-token" content={get_csrf_token()} />
+      <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
+      <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}></script>
+    </head>
     <body class="h-full">
       <%= @inner_content %>
     </body>

--- a/test/identicon_web/home_live_test.exs
+++ b/test/identicon_web/home_live_test.exs
@@ -14,4 +14,11 @@ defmodule IdenticonWeb.HomeLiveTest do
     {:ok, view, _html} = live(build_conn(), "/?u=bob")
     assert has_element?(view, "img")
   end
+
+  test "submit generates preview" do
+    {:ok, view, _html} = live(build_conn(), "/")
+    form = element(view, "form")
+    render_submit(form, %{"username" => "alice"})
+    assert has_element?(view, "img[src='/identicon/alice']")
+  end
 end


### PR DESCRIPTION
## Summary
- add standard HTML head with CSRF meta tag and asset links
- test generating preview on form submit

## Testing
- `mix test` *(fails: Can't continue due to errors on dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684ad667907483338b3f347de28e0b9e